### PR TITLE
Update index.ts to fix pour pattern mapping

### DIFF
--- a/xbloom-mcp-remote/supabase/functions/xbloom-mcp/index.ts
+++ b/xbloom-mcp-remote/supabase/functions/xbloom-mcp/index.ts
@@ -303,8 +303,8 @@ const TOOLS = [
 
 // --- Tool implementations ---
 
-const PATTERN_MAP: Record<string, number> = { centered: 1, circular: 2, spiral: 3 };
-const PATTERN_REV: Record<number, string> = { 1: "centered", 2: "circular", 3: "spiral" };
+const PATTERN_MAP: Record<string, number> = { centered: 1, spiral: 2, circular: 3 };
+const PATTERN_REV: Record<number, string> = { 1: "centered", 2: "spiral", 3: "circular" };
 
 interface Pour {
   volume_ml?: number;

--- a/xbloom-mcp-remote/supabase/functions/xbloom-mcp/index.ts
+++ b/xbloom-mcp-remote/supabase/functions/xbloom-mcp/index.ts
@@ -408,7 +408,7 @@ async function createTeaRecipe(args: Record<string, unknown>, creds: UserCredent
     volume: Math.min(Number(s.volume_ml ?? 80), 90),
     temperature: Number(s.temperature_c ?? 85),
     flowRate: Number(s.flow_rate ?? 3.0),
-    pattern: 2, // circular
+    pattern: 3, // circular
     pausing: Math.min(Number(s.steep_seconds ?? 120), 360),
     isEnableVibrationBefore: 2,
     isEnableVibrationAfter: 2,


### PR DESCRIPTION
## Disclaimer
I do not have the ability to test these fixes, but confirmed the issue through trial and error via the Claude MCP. Recommend confirming in test environment prior to merge. 

## Summary
Two related bugs caused incorrect pour patterns to be sent to the XBloom API:
1. `PATTERN_MAP` and `PATTERN_REV` had `circular` and `spiral` swapped relative to what the XBloom app actually renders
2. `createTeaRecipe` used a hardcoded pattern value that became incorrect after fixing the map

## Root Cause

### Bug 1 — Pattern map swap (`index.ts` lines 306–307)

```typescript
// Before (incorrect)
const PATTERN_MAP: Record<string, number> = { centered: 1, circular: 2, spiral: 3 };
const PATTERN_REV: Record<number, string> = { 1: "centered", 2: "circular", 3: "spiral" };
```

The XBloom app renders numeric value `2` as "spiral" and `3` as "circular", which is the inverse of what the map was sending.

### Bug 2 — Hardcoded pattern in `createTeaRecipe` (`index.ts` line 411)

```typescript
// Before (incorrect after map fix)
pattern: 2, // circular
```

With the old broken map, `2` happened to display as "circular" in the app. After correcting the map, `2` now correctly means "spiral" — so the hardcoded value needed to be updated to `3` to preserve the intended circular behavior for tea steeps.

## Fix

```typescript
// PATTERN_MAP and PATTERN_REV (lines 306–307)
const PATTERN_MAP: Record<string, number> = { centered: 1, spiral: 2, circular: 3 };
const PATTERN_REV: Record<number, string> = { 1: "centered", 2: "spiral", 3: "circular" };

// createTeaRecipe hardcoded pattern (line 411)
pattern: 3, // circular
```

## How This Was Discovered
Recipes created via the MCP server with `pattern: "spiral"` consistently displayed as "circular" in the iOS app and on share links. Testing confirmed:
- Sending `spiral` (→ `3`) displayed as "circular" in the app
- Sending `circular` (→ `2`) displayed as "spiral" in the app
- Manually setting a pour to "spiral" in the app saved value `2` to the API
- `centered` (→ `1`) was unaffected

The bug was masked during round-trip testing because `fetch_recipe` uses the same inverted `PATTERN_REV` map, making fetched data appear consistent with what was sent.

The tea recipe bug was caught by creating a test tea recipe after the map fix and observing it still showed spiral instead of circular in the app, tracing it back to the hardcoded `pattern: 2`.

## Impact
- All coffee recipes created or edited via the MCP server with `spiral` or `circular` patterns displayed the wrong pattern in the app
- All tea recipes brewed with spiral instead of the intended circular pattern
- `centered` patterns were unaffected in both cases
- The machine may also have been executing the wrong physical pour pattern