### PR TITLE
Stop the health catch-all from answering OAuth discovery probes

### DIFF
--- a/xbloom-mcp-remote/supabase/config.toml
+++ b/xbloom-mcp-remote/supabase/config.toml
@@ -385,7 +385,10 @@ s3_secret_key = "env(S3_SECRET_KEY)"
 
 [functions.xbloom-mcp]
 enabled = true
-verify_jwt = true
+# Must stay false: OAuth discovery, /register, /authorize and /token are all called
+# by clients that have no Supabase JWT. Gateway JWT verification 401s them before the
+# function runs, which breaks the connector.
+verify_jwt = false
 import_map = "./functions/xbloom-mcp/deno.json"
 # Uncomment to specify a custom file path to the entrypoint.
 # Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx

--- a/xbloom-mcp-remote/supabase/functions/xbloom-mcp/index.ts
+++ b/xbloom-mcp-remote/supabase/functions/xbloom-mcp/index.ts
@@ -1133,20 +1133,32 @@ Deno.serve(async (req: Request) => {
     return new Response(null, { status: 200, headers: CORS_HEADERS });
   }
 
-  // OAuth discovery
-  if (req.method === "GET" && (path.endsWith("/.well-known/oauth-protected-resource") || path.includes("oauth-protected-resource"))) {
-    return jsonResponse({ resource: BASE_URL, authorization_servers: [BASE_URL], bearer_methods_supported: ["header"] });
-  }
-  if (req.method === "GET" && (path.endsWith("/.well-known/oauth-authorization-server") || path.includes("oauth-authorization-server"))) {
-    return jsonResponse({
-      issuer: BASE_URL,
-      authorization_endpoint: `${BASE_URL}/authorize`,
-      token_endpoint: `${BASE_URL}/token`,
-      registration_endpoint: `${BASE_URL}/register`,
-      response_types_supported: ["code"],
-      grant_types_supported: ["authorization_code", "refresh_token"],
-      token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
-      code_challenge_methods_supported: ["S256", "plain"],
+  // OAuth discovery. Every .well-known probe is answered here and nowhere else: an
+  // unknown one must 404 rather than fall through to the health handler below, which
+  // would 200 with a document containing no endpoints — clients accept that as valid
+  // metadata, find no registration_endpoint, and abandon the OAuth flow.
+  if (req.method === "GET" && path.includes("/.well-known/")) {
+    if (path.includes("oauth-protected-resource")) {
+      return jsonResponse({ resource: BASE_URL, authorization_servers: [BASE_URL], bearer_methods_supported: ["header"] });
+    }
+    // openid-configuration serves the same document: RFC 8414 puts the canonical URL
+    // at the origin root (supabase.co/.well-known/...), which belongs to Supabase's
+    // gateway and 401s before reaching this function. Clients that fall back to a
+    // path-appended probe reach us here, so both names must resolve.
+    if (path.includes("oauth-authorization-server") || path.includes("openid-configuration")) {
+      return jsonResponse({
+        issuer: BASE_URL,
+        authorization_endpoint: `${BASE_URL}/authorize`,
+        token_endpoint: `${BASE_URL}/token`,
+        registration_endpoint: `${BASE_URL}/register`,
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
+        token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
+        code_challenge_methods_supported: ["S256", "plain"],
+      });
+    }
+    return new Response(JSON.stringify({ error: "not_found" }), {
+      status: 404, headers: { "Content-Type": "application/json", ...CORS_HEADERS },
     });
   }
 


### PR DESCRIPTION
Fixes the connector error: *"Couldn't register with Xbloom's sign-in service."*

## The bug

`/register` was never broken — Claude never called it. The edge function logs show **zero POSTs to `/register`**, but one revealing hit:

```
GET | 200 | .../functions/v1/xbloom-mcp/.well-known/openid-configuration
```

The trailing health handler answered **every** unmatched GET:

```ts
if (req.method === "GET") return jsonResponse({ name: "xbloom-mcp", status: "ok" });
```

So Claude's discovery probe for `/.well-known/openid-configuration` got `{"name":"xbloom-mcp","status":"ok"}` with a `200`. Claude accepted that as authorization-server metadata, found no `registration_endpoint` in it, and gave up. A `404` would have made it keep looking; the `200` made it stop and trust a document with no endpoints.

## Why discovery landed there

RFC 8414 puts the canonical metadata URL at the **origin root**:

```
https://<ref>.supabase.co/.well-known/oauth-authorization-server/functions/v1/xbloom-mcp
```

That path belongs to Supabase's API gateway, not the function — it returns `401 No API key found` and can never route to an edge function. Clients therefore fall back to path-appended probes, which are the only discovery URLs that reach our code on `*.supabase.co`.

## The fix

- Route every `/.well-known/*` probe explicitly; unknown ones now `404` instead of falling through to the health handler.
- Serve the same metadata document for `openid-configuration` as for `oauth-authorization-server`.
- Set `verify_jwt = false` for `xbloom-mcp` in `config.toml` to match the deployed state. It declared `true` while the function actually ran with `--no-verify-jwt`, so a plain `supabase functions deploy` would have switched on gateway JWT checks and 401'd every OAuth and MCP request.

## Verification

Against the deployed function:

| Check | Result |
|---|---|
| `discover -> register -> authorize -> token` | issues a working access + refresh token pair |
| PKCE S256, wrong verifier | still rejected (`invalid_grant`) |
| Unregistered `redirect_uri` | still `400` |
| `tools/list` | still returns 7 tools |
| Plain deploy (no `--no-verify-jwt`) | function stays reachable |

Discovery suite went from 3 failing assertions to 6/6 passing.

## Not included

Two things surfaced during the investigation and were deliberately left out:

1. **`WWW-Authenticate: Bearer resource_metadata=...`** — the spec's durable escape hatch from the root-path constraint. It only triggers OAuth if `initialize` returns `401`, which would break authless clients (`getSessionKey` accepts an `Mcp-Session-Id` as well as a bearer token). OAuth-gated vs authless is a product decision, not a bug fix.
2. **`xbloom-authorize` / `xbloom-token`** — dead but still-deployed functions that re-implement OAuth without the hardening from 6daeb50. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth discovery behavior and gateway JWT policy for a public integration endpoint; misconfiguration could block all connector sign-in, but the fix aligns config with required unauthenticated OAuth entrypoints.
> 
> **Overview**
> Fixes connector failures where clients never reached dynamic registration because **OAuth discovery probes were answered by the generic health GET handler** (`200` with `name`/`status` instead of `registration_endpoint`).
> 
> **Routing:** All `GET` paths under `/.well-known/` are handled explicitly—`oauth-protected-resource`, `oauth-authorization-server`, and **`openid-configuration`** (same metadata document as authorization-server for path-appended probes). Unrecognized well-known URLs return **404** so they no longer fall through to health.
> 
> **Deploy config:** `verify_jwt` for `xbloom-mcp` is set to **`false`** with documentation so the Supabase gateway does not 401 OAuth/MCP traffic (discovery, `/register`, `/authorize`, `/token`) that has no Supabase JWT—a plain deploy would otherwise diverge from `--no-verify-jwt` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fb35e27bc7e944ff9bee6f2314f32f63e4fc782. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->