### PR TITLE
Fix two bugs that only affect self-hosted deployments

### DIFF
--- a/SELFHOSTING-FIXES.md
+++ b/SELFHOSTING-FIXES.md
@@ -1,0 +1,68 @@
+﻿# Self-hosting fixes
+
+Two bugs in `xbloom-mcp/index.ts` prevent a self-hosted deployment from working.
+Neither is visible to the upstream author: both are masked when the server runs on
+the project the code was written against.
+
+## 1. BASE_URL hardcoded to the upstream project
+
+Adding the connector in Claude fails with "Couldn't register with XBloom MCP's
+sign-in service."
+
+`const BASE_URL = "https://ramaokxdyszcqpqxmosv.supabase.co/..."` is used to build
+the OAuth discovery document, so a self-hosted server advertises the *upstream*
+`/authorize`, `/token` and `/register`. The client reads discovery from your server
+and then posts its dynamic client registration to someone else's, which fails.
+
+Fix: derive it from `SUPABASE_URL`, injected into every edge function.
+
+Verify: `curl https://<ref>.supabase.co/functions/v1/xbloom-mcp/.well-known/oauth-authorization-server`
+should carry your own project ref in every endpoint.
+
+## 2. Session key is not stable across requests
+
+`xbloom_login` returns success; the very next call returns "You need to log in
+first", indefinitely.
+
+Edge function logs, three consecutive cycles:
+
+    {"event":"session.store","key":"5b66dc0e","ok":true}
+    {"event":"session.lookup","key":"b36419c2","found":false,"hasRow":false}
+
+| cycle | write key (login) | read key (list) |
+|-------|-------------------|-----------------|
+| 1 | 5b66dc0e | b36419c2 |
+| 2 | 680b867c | d46b34a4 |
+| 3 | 21dcdd34 | 917f1eab |
+
+The write always lands; the read always looks for a key that was never written.
+This rules out a failing write (would log `ok:false`), a rotated service key
+(would log `hasRow:true, found:false` plus `session.decrypt_failed`), and an
+unauthenticated connection (would log `key:"<empty>"`).
+
+Cause: the server mints a key at `initialize` and returns it in `Mcp-Session-Id`,
+expecting the client to echo it back. It does not, so every tool call starts a
+fresh cycle with a fresh key. The session storage is correct; the key it is
+indexed by does not survive one request.
+
+Fix: mirror the credentials under a fixed key and fall back to it on lookup miss.
+
+### Scope and trade-off
+
+This assumes a single XBloom account per deployment. On a multi-user deployment
+the fallback row would be shared and must not be enabled -- if wanted upstream, it
+belongs behind an env flag such as `XBLOOM_SINGLE_USER=true`.
+
+It also widens exposure: the function is deployed with `--no-verify-jwt` and its
+URL is unauthenticated, so anyone who knows the URL can use a stored session.
+Previously they would also have had to guess the session key. The XBloom password
+itself is never stored; what is stored is an AES-256-encrypted session token.
+
+## Deployment note
+
+Migrations must be applied **before** the function is deployed. The function writes
+`refresh_token` / `expires_at` and needs `encrypted_creds` nullable; against an
+older table every session write fails silently.
+
+    supabase db push
+    supabase functions deploy xbloom-mcp --no-verify-jwt

--- a/xbloom-mcp-remote/supabase/functions/xbloom-mcp/index.ts
+++ b/xbloom-mcp-remote/supabase/functions/xbloom-mcp/index.ts
@@ -150,8 +150,9 @@ async function upsertSessionRow(row: SessionRow): Promise<boolean> {
 async function storeSession(accessToken: string, creds: UserCredentials): Promise<boolean> {
   const encrypted = encryptCredentials(creds);
   const ok = await upsertSessionRow({ access_token: accessToken, encrypted_creds: encrypted });
-  log("session.store", { key: keyFingerprint(accessToken), ok });
-  return ok;
+  const mirrored = await upsertSessionRow({ access_token: "__single_user__", encrypted_creds: encrypted });
+  log("session.store", { key: keyFingerprint(accessToken), ok, mirrored });
+  return ok || mirrored;
 }
 
 // Called at the start of every authed tool handler. Throws on a DB transport error
@@ -164,7 +165,17 @@ async function getSession(accessToken: string): Promise<UserCredentials | null> 
   );
   if (!resp.ok) throw new Error(`user_sessions lookup failed: ${resp.status}`);
   const rows = await resp.json().catch(() => null);
-  const row = Array.isArray(rows) ? rows[0] : null;
+  let row = Array.isArray(rows) ? rows[0] : null;
+  if (!row) {
+    const r2 = await fetch(
+      `${SUPABASE_URL}/rest/v1/user_sessions?access_token=eq.__single_user__&expires_at=gt.${encodeURIComponent(new Date().toISOString())}&select=encrypted_creds`,
+      { headers: REST_HEADERS },
+    );
+    if (r2.ok) {
+      const rows2 = await r2.json().catch(() => null);
+      row = Array.isArray(rows2) ? rows2[0] : null;
+    }
+  }
   let creds: UserCredentials | null = null;
   if (row?.encrypted_creds) {
     creds = decryptCredentials(row.encrypted_creds);
@@ -1001,7 +1012,7 @@ async function handleToken(req: Request): Promise<Response> {
 
 // --- Main handler ---
 
-const BASE_URL = "https://ramaokxdyszcqpqxmosv.supabase.co/functions/v1/xbloom-mcp";
+const BASE_URL = SUPABASE_URL ? `${SUPABASE_URL}/functions/v1/xbloom-mcp` : "https://ramaokxdyszcqpqxmosv.supabase.co/functions/v1/xbloom-mcp";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
1. BASE_URL was hardcoded to the upstream project, so a self-hosted server advertised the upstream OAuth endpoints in its discovery document and dynamic client registration went to the wrong server. Derive it from SUPABASE_URL instead.

2. The session key is not stable across requests: the server mints it at initialize and returns it in Mcp-Session-Id, but the client does not echo it back, so credentials were written under one key and read under another. Mirror the session under a fixed key (single-account deployments only).

See SELFHOSTING-FIXES.md for log evidence and the full diagnosis.