### PR TITLE
Fix self-hosted OAuth connector registration via Cloudflare Worker proxy

### DIFF
--- a/SELFHOSTING-FIXES.md
+++ b/SELFHOSTING-FIXES.md
@@ -1,0 +1,68 @@
+﻿# Self-hosting fixes
+
+Two bugs in `xbloom-mcp/index.ts` prevent a self-hosted deployment from working.
+Neither is visible to the upstream author: both are masked when the server runs on
+the project the code was written against.
+
+## 1. BASE_URL hardcoded to the upstream project
+
+Adding the connector in Claude fails with "Couldn't register with XBloom MCP's
+sign-in service."
+
+`const BASE_URL = "https://ramaokxdyszcqpqxmosv.supabase.co/..."` is used to build
+the OAuth discovery document, so a self-hosted server advertises the *upstream*
+`/authorize`, `/token` and `/register`. The client reads discovery from your server
+and then posts its dynamic client registration to someone else's, which fails.
+
+Fix: derive it from `SUPABASE_URL`, injected into every edge function.
+
+Verify: `curl https://<ref>.supabase.co/functions/v1/xbloom-mcp/.well-known/oauth-authorization-server`
+should carry your own project ref in every endpoint.
+
+## 2. Session key is not stable across requests
+
+`xbloom_login` returns success; the very next call returns "You need to log in
+first", indefinitely.
+
+Edge function logs, three consecutive cycles:
+
+    {"event":"session.store","key":"5b66dc0e","ok":true}
+    {"event":"session.lookup","key":"b36419c2","found":false,"hasRow":false}
+
+| cycle | write key (login) | read key (list) |
+|-------|-------------------|-----------------|
+| 1 | 5b66dc0e | b36419c2 |
+| 2 | 680b867c | d46b34a4 |
+| 3 | 21dcdd34 | 917f1eab |
+
+The write always lands; the read always looks for a key that was never written.
+This rules out a failing write (would log `ok:false`), a rotated service key
+(would log `hasRow:true, found:false` plus `session.decrypt_failed`), and an
+unauthenticated connection (would log `key:"<empty>"`).
+
+Cause: the server mints a key at `initialize` and returns it in `Mcp-Session-Id`,
+expecting the client to echo it back. It does not, so every tool call starts a
+fresh cycle with a fresh key. The session storage is correct; the key it is
+indexed by does not survive one request.
+
+Fix: mirror the credentials under a fixed key and fall back to it on lookup miss.
+
+### Scope and trade-off
+
+This assumes a single XBloom account per deployment. On a multi-user deployment
+the fallback row would be shared and must not be enabled -- if wanted upstream, it
+belongs behind an env flag such as `XBLOOM_SINGLE_USER=true`.
+
+It also widens exposure: the function is deployed with `--no-verify-jwt` and its
+URL is unauthenticated, so anyone who knows the URL can use a stored session.
+Previously they would also have had to guess the session key. The XBloom password
+itself is never stored; what is stored is an AES-256-encrypted session token.
+
+## Deployment note
+
+Migrations must be applied **before** the function is deployed. The function writes
+`refresh_token` / `expires_at` and needs `encrypted_creds` nullable; against an
+older table every session write fails silently.
+
+    supabase db push
+    supabase functions deploy xbloom-mcp --no-verify-jwt

--- a/SELFHOSTING-OAUTH-PROXY-FIX.md
+++ b/SELFHOSTING-OAUTH-PROXY-FIX.md
@@ -1,0 +1,170 @@
+# Self-hosted connector fails with "Couldn't register with xBloom's sign-in service"
+
+Even after applying the fixes in `SELFHOSTING-FIXES.md` (BASE_URL derived from
+`SUPABASE_URL`, and the `__single_user__` session mirror), adding the connector
+in Claude still fails at the very first step, before any XBloom login happens:
+
+> Couldn't register with xBloom's sign-in service. You can try again, or add
+> an OAuth Client ID in the connector settings.
+
+## Root cause
+
+Claude's MCP connector derives the OAuth `authorization_endpoint` /
+`token_endpoint` / `registration_endpoint` from the **bare origin** of the
+server URL you give it, not the full path. For a self-hosted deployment the
+server URL is necessarily something like:
+
+```
+https://<project-ref>.supabase.co/functions/v1/xbloom-mcp
+```
+
+So the client ends up trying:
+
+```
+https://<project-ref>.supabase.co/authorize
+https://<project-ref>.supabase.co/.well-known/oauth-authorization-server
+```
+
+i.e. at the bare project origin, dropping the `/functions/v1/xbloom-mcp`
+prefix entirely. This isn't a bug in `xbloom-mcp/index.ts` — the function's
+own `.well-known` handlers under `/functions/v1/xbloom-mcp/.well-known/*`
+already return the correct, self-referential discovery document (verified
+with curl). The problem is that path is never reached.
+
+Every Supabase project sits behind a fixed platform gateway that only routes
+a handful of prefixes (`/rest/v1`, `/auth/v1`, `/storage/v1`,
+`/functions/v1`, ...). Anything else at the bare origin — including
+`/authorize` and `/.well-known/*` — is intercepted by that gateway before it
+reaches any deployed function, and returns:
+
+```json
+{"error":"requested path is invalid"}
+```
+
+Confirmed directly:
+
+```
+curl https://<project-ref>.supabase.co/.well-known/oauth-authorization-server
+→ 404 {"error":"requested path is invalid"}
+
+curl https://<project-ref>.supabase.co/authorize?...
+→ 404 {"error":"requested path is invalid"}   # same error the browser shows
+```
+
+This is why the upstream author's single hosted instance was unaffected —
+irrelevant to whether it's the author's project or a self-hosted one, this
+would break *any* deployment whose MCP endpoint lives under a subpath rather
+than at a domain's root. It happened to surface now because self-hosting is
+the first time someone stood this up on a fresh project and hit the OAuth
+setup flow freshly (an already-authorized upstream connection wouldn't
+re-trigger discovery).
+
+**No code change inside the Supabase Edge Function can fix this.** The bare
+origin is owned by Supabase's own gateway, not by project code — nothing
+deployed under `/functions/v1/...` can ever answer requests at `/authorize`
+or `/.well-known/...` at the root.
+
+## Fix: a tiny reverse proxy in front of the Supabase URL
+
+Put a small edge proxy in front (Cloudflare Workers free tier works well)
+that:
+
+1. Answers `/.well-known/oauth-authorization-server`,
+   `/.well-known/openid-configuration`, and
+   `/.well-known/oauth-protected-resource` **itself**, self-referential to
+   the proxy's own origin.
+2. Transparently forwards everything else (`/authorize`, `/token`,
+   `/register`, `/sse`, `/message`, and the JSON-RPC root) through to the
+   real Supabase function.
+
+```js
+// worker.js
+const UPSTREAM = "https://<project-ref>.supabase.co/functions/v1/xbloom-mcp";
+
+function json(obj) {
+  return new Response(JSON.stringify(obj), {
+    headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+  });
+}
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    const origin = url.origin;
+
+    if (url.pathname === "/.well-known/oauth-protected-resource") {
+      return json({
+        resource: origin,
+        authorization_servers: [origin],
+        bearer_methods_supported: ["header"],
+      });
+    }
+
+    if (
+      url.pathname === "/.well-known/oauth-authorization-server" ||
+      url.pathname === "/.well-known/openid-configuration"
+    ) {
+      return json({
+        issuer: origin,
+        authorization_endpoint: `${origin}/authorize`,
+        token_endpoint: `${origin}/token`,
+        registration_endpoint: `${origin}/register`,
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
+        token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
+        code_challenge_methods_supported: ["S256", "plain"],
+      });
+    }
+
+    // Built from scratch rather than `new Request(upstreamUrl, request)`:
+    // reusing the incoming Request carries its Host header (the proxy's own
+    // hostname) through to fetch(), and Supabase's Cloudflare-fronted edge
+    // rejects that as a same-network loop (Cloudflare error 1042). Dropping
+    // Host lets fetch() set it correctly for the upstream origin.
+    const upstreamUrl = UPSTREAM + url.pathname + url.search;
+    const headers = new Headers(request.headers);
+    headers.delete("host");
+    const upstreamRequest = new Request(upstreamUrl, {
+      method: request.method,
+      headers,
+      body: request.method === "GET" || request.method === "HEAD" ? undefined : request.body,
+      redirect: "manual",
+    });
+    return fetch(upstreamRequest);
+  },
+};
+```
+
+```toml
+# wrangler.toml
+name = "xbloom-mcp-oauth-proxy"
+main = "worker.js"
+compatibility_date = "2026-08-01"
+```
+
+Deploy with `wrangler deploy` (or `deno run -A npm:wrangler deploy` if you
+don't want to install Node — Deno's npm compatibility runs wrangler fine).
+Then point the Claude connector at the **Worker's URL**, not the raw
+Supabase URL. Leave OAuth Client ID/Secret blank in the connector — dynamic
+client registration now works correctly since discovery is self-referential.
+
+### Gotcha hit along the way
+
+The first deploy of the proxy returned Cloudflare error 1042 on any POST
+(`/register`, `/token`) while GETs worked fine. Cause: constructing the
+proxied request as `new Request(upstreamUrl, request)` carries the original
+`Host` header through, and Supabase's own Cloudflare-fronted edge treats a
+mismatched Host as a same-network loop and blocks it. Fix: build the request
+from scratch, explicitly dropping the `Host` header (see code above) so
+`fetch()` sets it correctly for the upstream origin.
+
+## Suggested upstream fix
+
+Given this affects any deployment where the MCP endpoint isn't at a domain
+root, it'd be worth either:
+
+- Documenting the proxy requirement directly in `SELFHOSTING-FIXES.md`, or
+- Having `xbloom-mcp`'s own handler serve a 401 with a `WWW-Authenticate:
+  Bearer resource_metadata="..."` header per RFC 9728 on unauthenticated
+  requests, in case that lets compliant clients skip bare-origin guessing
+  entirely (untested — the proxy above is the confirmed-working fix).

--- a/xbloom-mcp-remote/cloudflare-proxy/.gitignore
+++ b/xbloom-mcp-remote/cloudflare-proxy/.gitignore
@@ -1,0 +1,2 @@
+.wrangler/
+node_modules/

--- a/xbloom-mcp-remote/cloudflare-proxy/worker.js
+++ b/xbloom-mcp-remote/cloudflare-proxy/worker.js
@@ -1,0 +1,71 @@
+// OAuth discovery front for the xbloom-mcp Supabase Edge Function.
+//
+// Supabase's own project gateway owns every path outside a handful of fixed
+// service prefixes (/rest/v1, /auth/v1, /functions/v1, ...). Anything else,
+// including /.well-known/* and /authorize at the bare origin, 404s before it
+// ever reaches the edge function. OAuth clients (including Claude's MCP
+// connector) derive the authorization/token endpoints from the bare origin of
+// the server URL, not the deeper /functions/v1/xbloom-mcp path — so discovery
+// can never succeed directly against the Supabase URL.
+//
+// This Worker owns the bare origin instead: it answers the two well-known
+// discovery documents itself (self-referential, pointing back at the Worker),
+// and transparently proxies every other request through to the real function.
+
+const UPSTREAM = "https://qvuxqpndhyhnykzcvgol.supabase.co/functions/v1/xbloom-mcp";
+
+function json(obj) {
+  return new Response(JSON.stringify(obj), {
+    headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+  });
+}
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    const origin = url.origin;
+
+    if (url.pathname === "/.well-known/oauth-protected-resource") {
+      return json({
+        resource: origin,
+        authorization_servers: [origin],
+        bearer_methods_supported: ["header"],
+      });
+    }
+
+    if (
+      url.pathname === "/.well-known/oauth-authorization-server" ||
+      url.pathname === "/.well-known/openid-configuration"
+    ) {
+      return json({
+        issuer: origin,
+        authorization_endpoint: `${origin}/authorize`,
+        token_endpoint: `${origin}/token`,
+        registration_endpoint: `${origin}/register`,
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
+        token_endpoint_auth_methods_supported: ["client_secret_post", "client_secret_basic"],
+        code_challenge_methods_supported: ["S256", "plain"],
+      });
+    }
+
+    // Everything else — /authorize, /token, /register, /sse, /message, and the
+    // JSON-RPC root — proxies straight through, path and query preserved.
+    //
+    // Built from scratch rather than `new Request(upstreamUrl, request)`: reusing
+    // the incoming Request carries its Host header (this Worker's own hostname)
+    // through to the fetch, and Supabase's Cloudflare-fronted edge rejects that
+    // as a same-network loop (error 1042). Dropping Host lets fetch() set it
+    // correctly for the upstream origin.
+    const upstreamUrl = UPSTREAM + url.pathname + url.search;
+    const headers = new Headers(request.headers);
+    headers.delete("host");
+    const upstreamRequest = new Request(upstreamUrl, {
+      method: request.method,
+      headers,
+      body: request.method === "GET" || request.method === "HEAD" ? undefined : request.body,
+      redirect: "manual",
+    });
+    return fetch(upstreamRequest);
+  },
+};

--- a/xbloom-mcp-remote/cloudflare-proxy/wrangler.toml
+++ b/xbloom-mcp-remote/cloudflare-proxy/wrangler.toml
@@ -1,0 +1,3 @@
+name = "xbloom-mcp-oauth-proxy"
+main = "worker.js"
+compatibility_date = "2026-08-01"

--- a/xbloom-mcp-remote/supabase/functions/xbloom-mcp/index.ts
+++ b/xbloom-mcp-remote/supabase/functions/xbloom-mcp/index.ts
@@ -150,8 +150,9 @@ async function upsertSessionRow(row: SessionRow): Promise<boolean> {
 async function storeSession(accessToken: string, creds: UserCredentials): Promise<boolean> {
   const encrypted = encryptCredentials(creds);
   const ok = await upsertSessionRow({ access_token: accessToken, encrypted_creds: encrypted });
-  log("session.store", { key: keyFingerprint(accessToken), ok });
-  return ok;
+  const mirrored = await upsertSessionRow({ access_token: "__single_user__", encrypted_creds: encrypted });
+  log("session.store", { key: keyFingerprint(accessToken), ok, mirrored });
+  return ok || mirrored;
 }
 
 // Called at the start of every authed tool handler. Throws on a DB transport error
@@ -164,7 +165,17 @@ async function getSession(accessToken: string): Promise<UserCredentials | null> 
   );
   if (!resp.ok) throw new Error(`user_sessions lookup failed: ${resp.status}`);
   const rows = await resp.json().catch(() => null);
-  const row = Array.isArray(rows) ? rows[0] : null;
+  let row = Array.isArray(rows) ? rows[0] : null;
+  if (!row) {
+    const r2 = await fetch(
+      `${SUPABASE_URL}/rest/v1/user_sessions?access_token=eq.__single_user__&expires_at=gt.${encodeURIComponent(new Date().toISOString())}&select=encrypted_creds`,
+      { headers: REST_HEADERS },
+    );
+    if (r2.ok) {
+      const rows2 = await r2.json().catch(() => null);
+      row = Array.isArray(rows2) ? rows2[0] : null;
+    }
+  }
   let creds: UserCredentials | null = null;
   if (row?.encrypted_creds) {
     creds = decryptCredentials(row.encrypted_creds);
@@ -1001,7 +1012,7 @@ async function handleToken(req: Request): Promise<Response> {
 
 // --- Main handler ---
 
-const BASE_URL = "https://ramaokxdyszcqpqxmosv.supabase.co/functions/v1/xbloom-mcp";
+const BASE_URL = SUPABASE_URL ? `${SUPABASE_URL}/functions/v1/xbloom-mcp` : "https://ramaokxdyszcqpqxmosv.supabase.co/functions/v1/xbloom-mcp";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
## Summary
- After applying the fixes in `SELFHOSTING-FIXES.md`, self-hosted deployments still fail to connect in Claude with "Couldn't register with xBloom's sign-in service."
- Root cause: Claude's MCP connector derives the OAuth `authorization_endpoint`/`token_endpoint`/`registration_endpoint` from the **bare origin** of the server URL, not the full `/functions/v1/xbloom-mcp` path. Every Supabase project's platform gateway intercepts anything at the bare origin outside a fixed set of prefixes (`/rest/v1`, `/auth/v1`, `/functions/v1`, ...) and returns `{"error":"requested path is invalid"}` before it ever reaches the deployed function — confirmed directly with curl against both `/authorize` and `/.well-known/oauth-authorization-server` at the bare origin.
- No code change inside the edge function can fix this, since that root path is owned by Supabase's platform, not project code.
- Adds `xbloom-mcp-remote/cloudflare-proxy/` — a small, free-tier Cloudflare Worker that serves the well-known discovery docs itself (self-referential to its own origin) and transparently proxies everything else (`/authorize`, `/token`, `/register`, `/sse`, `/message`, JSON-RPC root) through to the real Supabase function. Self-hosters point their Claude connector at the Worker's URL instead of the raw Supabase URL.
- Also documents a Cloudflare error 1042 gotcha hit along the way: proxying via `new Request(upstreamUrl, request)` carries the original Host header through, which Supabase's Cloudflare-fronted edge treats as a same-network loop and blocks. Fixed by rebuilding the request and dropping the Host header explicitly.
- Full writeup in `SELFHOSTING-OAUTH-PROXY-FIX.md`.

## Test plan
- [x] Verified `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource` via the Worker return self-referential URLs
- [x] Verified `/register`, `/authorize` (302 redirect with code), and health check proxy correctly through the Worker to the underlying Supabase function
- [x] Connected the Claude MCP connector against the Worker URL and confirmed it registers and connects successfully (previously failed with "Couldn't register with xBloom's sign-in service" against the raw Supabase URL)

https://claude.ai/code/session_01CiKJ4Fk9LBkFy7fCnWeM9x